### PR TITLE
Real month in logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,13 +76,13 @@ function log(level, text) {
     return arg instanceof Error ? arg.stack + EOL : arg;
   });
   text = util.format.apply(util, args);
-  
+
   var msg = {
     level: level,
     text: text,
     date: new Date()
   };
-  
+
   var transports = module.exports.transports;
   for (var i in transports) {
     // jshint -W089
@@ -113,7 +113,7 @@ function transportConsole(msg) {
 
 function transportFile(msg) {
   var text = format(msg, transportFile.format || module.exports.format);
-  
+
   if (undefined === transportFile.stream) {
     transportFile.file = transportFile.file || findLogPath(module.exports.appName);
     if (!transportFile.file) {
@@ -135,7 +135,7 @@ function transportFile(msg) {
   if (!transportFile.stream) {
     return;
   }
-  
+
   transportFile.stream.write(text + EOL);
 }
 
@@ -221,7 +221,7 @@ function findLogPath(appName) {
       }
     }
 
-    return { 
+    return {
       or: prepareDir,
       result: (this ? this.result : false) || path
     };
@@ -307,7 +307,7 @@ function formatConsole(msg) {
 }
 
 function formatFile(msg) {
-  var date = 
+  var date =
     msg.date.getFullYear() + '-' +
     pad(msg.date.getMonth()) + '-' +
     pad(msg.date.getDate()) + ' ' +

--- a/index.js
+++ b/index.js
@@ -288,7 +288,7 @@ function format(msg, formatter) {
     .replace('{level}', msg.level)
     .replace('{text}', msg.text)
     .replace('{y}', date.getFullYear())
-    .replace('{m}', pad(date.getMonth()))
+    .replace('{m}', pad(date.getMonth() + 1))
     .replace('{d}', pad(date.getDate()))
     .replace('{h}', pad(date.getHours()))
     .replace('{i}', pad(date.getMinutes()))
@@ -309,7 +309,7 @@ function formatConsole(msg) {
 function formatFile(msg) {
   var date =
     msg.date.getFullYear() + '-' +
-    pad(msg.date.getMonth()) + '-' +
+    pad(msg.date.getMonth() + 1) + '-' +
     pad(msg.date.getDate()) + ' ' +
     pad(msg.date.getHours()) + ':' +
     pad(msg.date.getMinutes()) + ':' +

--- a/index.spec.js
+++ b/index.spec.js
@@ -50,7 +50,7 @@ describe('format', () => {
   const msg = {
     level: 'info',
     text: 'test',
-    date: new Date(2000, 1, 1, 1, 1, 1)
+    date: new Date(2000, 0, 1, 1, 1, 1)
   };
 
   it('should call formatter if it\'s a function', () => {
@@ -64,7 +64,7 @@ describe('format', () => {
     const text = format(msg, '{y}:{m}:{d} {h}:{i}:{s}:{ms} {level} {text}');
     expect(text).to.equal('2000:01:01 01:01:01:0000 info test');
   });
-  
+
   it('should format console output', () => {
     expect(formatConsole(msg)).to.equals('[01:01:01:0000] [info] test');
   });
@@ -72,7 +72,7 @@ describe('format', () => {
   it('should format file output', () => {
     expect(formatFile(msg)).to.equals('[2000-01-01 01:01:01:0000] [info] test');
   });
-  
+
   it('should pad numeric', () => {
     expect(pad(1, 1)).to.equals('1');
     expect(pad(1)).to.equals('01');
@@ -92,7 +92,7 @@ describe('log levels', () => {
 describe('loadAppPackage', () => {
   it('should find package.json', () => {
     expect(loadAppPackage().name).to.equals(
-      'mocha', 
+      'mocha',
       'It has to load a mocha package, because it\'s an entry point'
     );
   });


### PR DESCRIPTION
Hey.
Since `getMonth()` returns an int from 0 to 11, log entries are misleading. The pr adds 1 to the month to make it human-readable.
Also, took the liberty to fix whitespace issues.