### PR TITLE
Fix issue with console level conversions on renderer process

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -20,6 +20,10 @@ if (ipcRenderer) {
   };
 
   ipcRenderer.on('__ELECTRON_LOG_RENDERER__', function(event, level, text) {
+    if (level ==='verbose')
+      level = 'log';
+    else if (level === 'silly')
+      level = 'debug';
     console[level](text);
   });
 }

--- a/renderer.js
+++ b/renderer.js
@@ -20,10 +20,12 @@ if (ipcRenderer) {
   };
 
   ipcRenderer.on('__ELECTRON_LOG_RENDERER__', function(event, level, text) {
-    if (level ==='verbose')
+    if (level === 'verbose') {
       level = 'log';
-    else if (level === 'silly')
+    } else if (level === 'silly') {
       level = 'debug';
+    }
+    
     console[level](text);
   });
 }


### PR DESCRIPTION
As the browser (specifically Chromium) do not support "verbose" and "silly", we need to convert them to their equivalents. Otherwise, we get an error in the console and the messages are not displayed.