### PR TITLE
Implement .log to match console API

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,8 @@ module.exports = {
   info:    log.bind(null, transports, 'info'),
   verbose: log.bind(null, transports, 'verbose'),
   debug:   log.bind(null, transports, 'debug'),
-  silly:   log.bind(null, transports, 'silly')
+  silly:   log.bind(null, transports, 'silly'),
+  log:     log.bind(null, transports, 'info')
 };
 
 if (electron && electron.ipcMain) {

--- a/renderer.js
+++ b/renderer.js
@@ -16,7 +16,8 @@ if (ipcRenderer) {
     info:    log.bind(null, 'info'),
     verbose: log.bind(null, 'verbose'),
     debug:   log.bind(null, 'debug'),
-    silly:   log.bind(null, 'silly')
+    silly:   log.bind(null, 'silly'),
+    log:     log.bind(null, 'info')
   };
 
   ipcRenderer.on('__ELECTRON_LOG_RENDERER__', function(event, level, text) {


### PR DESCRIPTION
Implement console.log().  This more closely matches the console API, which is useful for use with tools such as https://www.npmjs.com/package/redux-logger
