### PR TITLE
add os.homedir() to fallback prcesss.env.home is undefined

### DIFF
--- a/lib/transports/file/find-log-path.js
+++ b/lib/transports/file/find-log-path.js
@@ -2,6 +2,7 @@
 
 var fs   = require('fs');
 var path = require('path');
+var os   = require('os');
 var getAppName = require('./get-app-name');
 
 module.exports = findLogPath;
@@ -18,25 +19,26 @@ function findLogPath(appName) {
   }
 
   var dir;
+  var homeDir = os.homedir() ? os.homedir() : process.env['HOME'];
   switch (process.platform) {
     case 'linux': {
       dir = prepareDir(process.env['XDG_CONFIG_HOME'], appName)
-        .or(process.env['HOME'], '.config', appName)
+        .or(homeDir, '.config', appName)
         .or(process.env['XDG_DATA_HOME'], appName)
-        .or(process.env['HOME'], '.local', 'share', appName)
+        .or(homeDir, '.local', 'share', appName)
         .result;
       break;
     }
 
     case 'darwin': {
-      dir = prepareDir(process.env['HOME'], 'Library', 'Logs', appName)
-        .or(process.env['HOME'], 'Library', 'Application Support', appName)
+      dir = prepareDir(homeDir, 'Library', 'Logs', appName)
+        .or(homeDir, 'Library', 'Application Support', appName)
         .result;
       break;
     }
 
     case 'win32': {
-      dir = prepareDir(process.env['APPDATA'], appName)
+      dir = prepareDir(homeDir, appName)
         .or(process.env['USERPROFILE'], 'AppData', 'Roaming', appName)
         .result;
       break;

--- a/lib/transports/file/find-log-path.js
+++ b/lib/transports/file/find-log-path.js
@@ -18,8 +18,9 @@ function findLogPath(appName) {
     return false;
   }
 
+  var homeDir = os.homedir ? os.homedir() : process.env['HOME'];
+  
   var dir;
-  var homeDir = os.homedir() ? os.homedir() : process.env['HOME'];
   switch (process.platform) {
     case 'linux': {
       dir = prepareDir(process.env['XDG_CONFIG_HOME'], appName)
@@ -38,8 +39,8 @@ function findLogPath(appName) {
     }
 
     case 'win32': {
-      dir = prepareDir(homeDir, appName)
-        .or(process.env['USERPROFILE'], 'AppData', 'Roaming', appName)
+      dir = prepareDir(process.env['APPDATA'], appName)
+        .or(homeDir, 'AppData', 'Roaming', appName)
         .result;
       break;
     }


### PR DESCRIPTION
Hi, I am using webpack to build project in production and found out a problem which caused out 'Could not set a log file' as #22 . Turn out is definitely  DefinePlugin striped all process environment variable. so I figured out two solutions:
1.  in my webpack production defined some process environment variable.(eg HOME)
2. using `os.homedir()` as fallback to `process.env['HOME']` ,but I no sure ` os.homedir() `  is working before node js v4 or need a ponyfill [os-homedir](https://github.com/sindresorhus/os-homedir)

Thank your guy create an awesome project.This PR for your reference.

sincerely