### PR TITLE
Added a fix for renderer Illegal Invocation

### DIFF
--- a/lib/original-console.js
+++ b/lib/original-console.js
@@ -4,6 +4,7 @@
  * Save console methods for using when originals are overridden
  */
 module.exports = {
+  context: console,
   error:   console.error,
   warn:    console.warn,
   info:    console.info,

--- a/renderer.js
+++ b/renderer.js
@@ -31,7 +31,7 @@ if (ipcRenderer) {
       level = 'debug';
     }
 
-    originalConsole[level](text);
+    originalConsole[level].call(originalConsole.context, text);
   });
 }
 

--- a/test-projects/electron-log-test-node/main.spec.js
+++ b/test-projects/electron-log-test-node/main.spec.js
@@ -5,7 +5,8 @@ const helper = require('../spec-helper');
 
 const APP_NAME = 'electron-log-test-node';
 
-describe('node test project', () => {
+describe('node test project', function() {
+  this.timeout(6000)
   it('should write one line to a log file', () => {
     return helper.run(APP_NAME).then((logs) => {
       expect(logs.length).to.equal(2);

--- a/test-projects/electron-log-test-simple/main.spec.js
+++ b/test-projects/electron-log-test-simple/main.spec.js
@@ -6,7 +6,7 @@ const helper = require('../spec-helper');
 const APP_NAME = 'electron-log-test-simple';
 
 describe('simple test project', function() {
-  this.timeout(5000);
+  this.timeout(8000);
 
   it('should write one line to a log file', () => {
     return helper.run(APP_NAME).then((logs) => {


### PR DESCRIPTION
My team and I were experiencing a bug with the renderer logging: `TypeError: Illegal Invocation: ~/ProjectDir/node_modules/electron-log/renderer.js:34`. I tracked it down and found that the renderer logic wasn't calling `console[level]` with the correct context, leading to not logging the message along with a big fat error in the console.

As you can see below, the fix was quite simple. I would love to get this closed ASAP so we can use the newest version.