### PR TITLE
Allow color formatting in dev console

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-log",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "Just a very simple logging module for your Electron application",
   "main": "./index.js",
   "scripts": {

--- a/renderer.js
+++ b/renderer.js
@@ -24,21 +24,16 @@ if (ipcRenderer) {
 
   module.exports.default = module.exports;
 
-  ipcRenderer.on('__ELECTRON_LOG_RENDERER__', function(event, level, text) {
+  ipcRenderer.on('__ELECTRON_LOG_RENDERER__', function(event, level, data) {
     if (level === 'verbose') {
       level = 'log';
     } else if (level === 'silly') {
       level = 'debug';
     }
-    let msg = '';
-    let args = [];
-    if (Array.isArray(text)) {
-      msg = text.shift();
-      args = text;
-    } else {
-      msg = text;
-    }
-    originalConsole[level].call(originalConsole.context, msg, ...args);
+
+    originalConsole[level].apply(originalConsole.context,
+      typeof data === 'string' ? [data] : data
+    );
   });
 }
 

--- a/renderer.js
+++ b/renderer.js
@@ -31,7 +31,8 @@ if (ipcRenderer) {
       level = 'debug';
     }
 
-    originalConsole[level].apply(originalConsole.context,
+    originalConsole[level].apply(
+      originalConsole.context,
       typeof data === 'string' ? [data] : data
     );
   });

--- a/renderer.js
+++ b/renderer.js
@@ -30,8 +30,15 @@ if (ipcRenderer) {
     } else if (level === 'silly') {
       level = 'debug';
     }
-
-    originalConsole[level].call(originalConsole.context, text);
+    let msg = '';
+    let args = [];
+    if (Array.isArray(text)) {
+      msg = text.shift();
+      args = text;
+    } else {
+      msg = text;
+    }
+    originalConsole[level].call(originalConsole.context, msg, ...args);
   });
 }
 


### PR DESCRIPTION
Allow user to return an array from the rendererConsole format
function which can be used for color formatting.

Resolves Issue #87