### PR TITLE
Adds ability to set log labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ electron-log supports the following log levels:
 
     error, warn, info, verbose, debug, silly
 
+### Set log label
+
+You can set a label for each logger via `log.setLabel('module1');`
+This will be accessible in the format function as `msg.label`
+
 ### Transport
 
 Transport is a simple function which requires an object which describes
@@ -64,7 +69,7 @@ var format = require('util');
 
 log.transports.console = function(msg) {
   var text = util.format.apply(util, msg.data);
-  console.log(`[${msg.date.toLocaleTimeString()} ${msg.level}] ${text}`);
+  console.log(`[${msg.date.toLocaleTimeString()} ${msg.level}] ${msg.label} ${text}`);
 };
 ```
 Please be aware that if you override a transport function the default
@@ -78,7 +83,7 @@ log.transports.console.level = 'warn';
 
 /**
  * Set output format template. Available variables:
- * Main: {level}, {text}
+ * Main: {level}, {label}, {text}
  * Date: {y},{m},{d},{h},{i},{s},{ms},{z}
  */
 log.transports.console.format = '{h}:{i}:{s}:{ms} {text}';

--- a/electron-log.d.ts
+++ b/electron-log.d.ts
@@ -10,6 +10,7 @@ export interface ILogMessage {
   data: any[];
   date: Date;
   level: LogLevel;
+  label: string;
 }
 
 export declare interface ITransport {
@@ -61,6 +62,7 @@ declare interface IElectronLog {
   debug(...params: any[]): void;
   silly(...params: any[]): void;
   log(...params: any[]): void;
+  setLabel(n: string): void;
 }
 
 export declare function error(...params: any[]): void;
@@ -70,6 +72,7 @@ export declare function verbose(...params: any[]): void;
 export declare function debug(...params: any[]): void;
 export declare function silly(...params: any[]): void;
 export declare function log(...params: any[]): void;
+export declare function setLabel(n: string): void;
 export declare const transports: ITransports;
 
 declare const _d: IElectronLog;

--- a/lib/format.js
+++ b/lib/format.js
@@ -20,6 +20,7 @@ function format(msg, formatter) {
   return formatter
     .replace('{level}', msg.level)
     .replace('{text}', stringifyArray(msg.data))
+    .replace('{label}', msg.label)
     .replace('{y}', date.getFullYear())
     .replace('{m}', pad(date.getMonth() + 1))
     .replace('{d}', pad(date.getDate()))

--- a/lib/format.spec.js
+++ b/lib/format.spec.js
@@ -8,7 +8,8 @@ describe('format', function() {
   var msg = {
     level: 'info',
     data: ['test'],
-    date: new Date(2000, 0, 1, 1, 1, 1)
+    date: new Date(2000, 0, 1, 1, 1, 1),
+    label: 'test-label'
   };
 
   it('should call formatter if it\'s a function', function() {
@@ -20,9 +21,9 @@ describe('format', function() {
   it('should format by template', function() {
     var text = format.format(
       msg,
-      '{y}:{m}:{d} {h}:{i}:{s}:{ms} {level} {text}'
+      '{y}:{m}:{d} {h}:{i}:{s}:{ms} {level} {text} {label}'
     );
-    expect(text).to.equal('2000:01:01 01:01:01:000 info test');
+    expect(text).to.equal('2000:01:01 01:01:01:000 info test test-label');
   });
 
   it('should format timezone offset', function() {

--- a/lib/log.js
+++ b/lib/log.js
@@ -5,13 +5,14 @@ var LEVELS = ['error', 'warn', 'info', 'verbose', 'debug', 'silly'];
 
 module.exports = log;
 
-function log(transports, level, text) {
-  var data = Array.prototype.slice.call(arguments, 2);
+function log(transports, level, getLabel, text) {
+  var data = Array.prototype.slice.call(arguments, 3);
 
   var msg = {
     data: data,
     date: new Date(),
-    level: level
+    level: level,
+    label: getLabel()
   };
 
   for (var i in transports) {

--- a/lib/log.spec.js
+++ b/lib/log.spec.js
@@ -7,6 +7,7 @@ var log    = require('./log');
 var logModule  = require('rewire')('./log');
 //noinspection JSUnresolvedFunction
 var compareLevels  = logModule.__get__('compareLevels');
+var getLabel = function() { return 'test-label'; };
 
 describe('log', function() {
   it('should call a transport protocol', function() {
@@ -18,10 +19,11 @@ describe('log', function() {
     };
 
     //noinspection JSUnresolvedFunction
-    log(transports, 'info', 'test');
+    log(transports, 'info', getLabel, 'test');
 
     expect(journal[0].data).to.deep.equal(['test']);
     expect(journal[0].level).to.equal('info');
+    expect(journal[0].label).to.equal('test-label');
   });
 
 

--- a/main.js
+++ b/main.js
@@ -20,16 +20,18 @@ var transports = {
   rendererConsole: transportRendererConsole
 };
 
+var ELECTRON_LOG_LABEL = '';
+
 module.exports = {
   transports: transports,
-
-  error:   log.bind(null, transports, 'error'),
-  warn:    log.bind(null, transports, 'warn'),
-  info:    log.bind(null, transports, 'info'),
-  verbose: log.bind(null, transports, 'verbose'),
-  debug:   log.bind(null, transports, 'debug'),
-  silly:   log.bind(null, transports, 'silly'),
-  log:     log.bind(null, transports, 'info')
+  error:      log.bind(null, transports, 'error', getLabel),
+  warn:       log.bind(null, transports, 'warn', getLabel),
+  info:       log.bind(null, transports, 'info', getLabel),
+  verbose:    log.bind(null, transports, 'verbose', getLabel),
+  debug:      log.bind(null, transports, 'debug', getLabel),
+  silly:      log.bind(null, transports, 'silly', getLabel),
+  log:        log.bind(null, transports, 'info', getLabel),
+  setLabel:   (label) => { ELECTRON_LOG_LABEL = label; }
 };
 
 module.exports.default = module.exports;
@@ -42,9 +44,17 @@ if (electron && electron.ipcMain) {
   }
 }
 
-function onRendererLog(event, data) {
+function getLabel() {
+  return ELECTRON_LOG_LABEL;
+}
+
+function onRendererLog(event, data, label) {
+
+  function getRendererLabel() { return label; }
+
   if (Array.isArray(data)) {
     data.unshift(transports);
+    data.splice(2, 0, getRendererLabel);
     log.apply(null, data);
   }
 }

--- a/renderer.js
+++ b/renderer.js
@@ -10,16 +10,18 @@ try {
 }
 
 var originalConsole = require('./lib/original-console');
+var ELECTRON_LOG_LABEL = '';
 
 if (ipcRenderer) {
   module.exports = {
-    error:   log.bind(null, 'error'),
-    warn:    log.bind(null, 'warn'),
-    info:    log.bind(null, 'info'),
-    verbose: log.bind(null, 'verbose'),
-    debug:   log.bind(null, 'debug'),
-    silly:   log.bind(null, 'silly'),
-    log:     log.bind(null, 'info')
+    error:    log.bind(null, 'error'),
+    warn:     log.bind(null, 'warn'),
+    info:     log.bind(null, 'info'),
+    verbose:  log.bind(null, 'verbose'),
+    debug:    log.bind(null, 'debug'),
+    silly:    log.bind(null, 'silly'),
+    log:      log.bind(null, 'info'),
+    setLabel: (label) => { ELECTRON_LOG_LABEL = label; }
   };
 
   module.exports.default = module.exports;
@@ -40,6 +42,7 @@ if (ipcRenderer) {
 
 function log() {
   var data = Array.prototype.slice.call(arguments);
+  var label = ELECTRON_LOG_LABEL;
 
   data = data.map(function(obj) {
     if (obj instanceof Error) {
@@ -49,5 +52,5 @@ function log() {
     return obj;
   });
 
-  ipcRenderer.send('__ELECTRON_LOG__', data);
+  ipcRenderer.send('__ELECTRON_LOG__', data, label);
 }


### PR DESCRIPTION
Users can now label their loggers in each module by calling
log.setLabel('<module_name>'). The label will be accessible in the
format function as msg.label

Resolves Issue #89