### PR TITLE
Make logging context aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ log.transports.console.level = 'warn';
 
 /**
  * Set output format template. Available variables:
- * Main: {level}, {text}
+ * Main: {level}, {text} {context}
  * Date: {y},{m},{d},{h},{i},{s},{ms},{z}
  */
 log.transports.console.format = '{h}:{i}:{s}:{ms} {text}';
@@ -96,7 +96,7 @@ console transport.
 ```js
 // Same as for console transport
 log.transports.file.level = 'warn';
-log.transports.file.format = '{h}:{i}:{s}:{ms} {text}';
+log.transports.file.format = '{h}:{i}:{s}:{ms} in {context} {text}';
 
 // Set approximate maximum log size in bytes. When it exceeds,
 // the archived log will be saved as the log.old.log file
@@ -123,6 +123,13 @@ to specify another path, just set the appName property:
 log.transports.file.appName = 'test';
 ```
 This value should be set before the first log method call.
+
+### Context-aware logging
+By default each log entry includes the current context. The context is defined by 
+[electron's `process.type` property](https://electronjs.org/docs/api/process#processtype).
+In other contexts (e.g. a worker script) you can set a different value.
+**Note:** Pay attention when changing this value inside the main or renderer process
+of electron, because it could caused undefined behaviour.
 
 ## Renderer process
 

--- a/lib/format.js
+++ b/lib/format.js
@@ -20,6 +20,7 @@ function format(msg, formatter) {
   return formatter
     .replace('{level}', msg.level)
     .replace('{text}', stringifyArray(msg.data))
+    .replace('{context}', process.type)
     .replace('{y}', date.getFullYear())
     .replace('{m}', pad(date.getMonth() + 1))
     .replace('{d}', pad(date.getDate()))

--- a/lib/format.spec.js
+++ b/lib/format.spec.js
@@ -36,4 +36,11 @@ describe('format', function() {
     expect(format.pad(1)).to.equals('01');
     expect(format.pad(10, 3)).to.equals('010');
   });
+
+  it('should format context', function() {
+    process.type = 'testing';
+    var text = format.format(null, '{context}');
+    expect(text).to.equal('testing');
+    delete process.type;
+  })
 });

--- a/lib/transports/console.js
+++ b/lib/transports/console.js
@@ -4,7 +4,7 @@ var format          = require('../format');
 var originalConsole = require('../original-console');
 
 transport.level  = 'silly';
-transport.format = '[{h}:{i}:{s}.{ms}] [{level}] {text}';
+transport.format = '[{h}:{i}:{s}.{ms}] [{context}] [{level}] {text}';
 
 module.exports = transport;
 

--- a/lib/transports/file/index.js
+++ b/lib/transports/file/index.js
@@ -7,7 +7,7 @@ var consoleTransport = require('../console');
 var findLogPath      = require('./find-log-path');
 
 transport.findLogPath  = findLogPath;
-transport.format       = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
+transport.format       = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{context}] [{level}] {text}';
 transport.level        = 'warn';
 transport.maxSize      = 1024 * 1024;
 transport.streamConfig = undefined;

--- a/lib/transports/renderer-console.js
+++ b/lib/transports/renderer-console.js
@@ -10,7 +10,7 @@ try {
 var format = require('../format');
 
 transport.level  = BrowserWindow ? 'silly' : false;
-transport.format = '[{h}:{i}:{s}.{ms}] {text}';
+transport.format = '[{h}:{i}:{s}.{ms}] [{context}] {text}';
 
 module.exports = transport;
 


### PR DESCRIPTION
This change will add a new property `{context}` to formatter which will be replaced with [electron's `process.type` property](https://electronjs.org/docs/api/process#processtype) ('renderer' or 'main').

Resolves #75 
It's also possible to set `process.type` in, for example, a worker script.