### PR TITLE
Add named loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ log.transports.file.appName = 'test';
 ```
 This value should be set before the first log method call.
 
+### Named loggers
+It is possible to create named loggers. These will prepend each log message with their name.
+Named loggers are available in both main and renderer process and will be cached.
+
+```js
+var log = require('electron-log');
+var myLogger = log.createNamedLogger('MyLogger');
+
+myLogger.info('Hello, log');
+// Logs something like: '10:30:21:123 [info] MyLogger: some message'
+``
+
+The created logger will inherit the `transports` options but you can change them
+for each logger individually.
+
+**Note:** If you change the default `transports` options globally you should do
+it before creating a named logger.
+
 ## Renderer process
 
 Since version 2.0.0 this package works differently in main and renderer

--- a/index.spec.js
+++ b/index.spec.js
@@ -5,10 +5,26 @@ var index  = require('./index');
 
 
 describe('package', function() {
+  var levels = ['error', 'warn', 'info', 'verbose', 'debug', 'silly'];
+
   it('should contains npm level methods', function() {
-    var levels = ['error', 'warn', 'info', 'verbose', 'debug', 'silly'];
     levels.forEach(function (level) {
       expect(index[level]).to.be.a('function');
     });
+  });
+
+  it('should contains all log leve methods in named logger', function() {
+    var logger = index.createNamedLogger('SomeLogger')
+    levels.forEach(function (level) {
+      expect(logger[level]).to.be.a('function');
+    });
+  });
+
+  it('should have distinct config for any named logger', function () {
+    var logger = index.createNamedLogger('SomeLogger')
+    index.transports.someVal = true
+    expect(logger.transports.someVal).be.an('undefined')
+    logger.transports.otherVal = 12
+    expect(index.transports.otherVal).be.an('undefined')
   });
 });

--- a/main.js
+++ b/main.js
@@ -61,7 +61,7 @@ function onRendererLog(event, data) {
 
 function createNamedLogger(name) {
   if (!namedLoggers[name]) {
-    namedLoggers[name] = createLogFunctions(transports, name + ':');
+    namedLoggers[name] = createLogFunctions(Object.assign({}, transports), name + ':');
   }
 
   return namedLoggers[name];

--- a/renderer.js
+++ b/renderer.js
@@ -47,7 +47,7 @@ function createLogFunctions(prependMessage) {
 
 function createNamedLogger(name) {
   if (!namedLoggers[name]) {
-    namedLoggers[name] = createLogFunctions(transports, name + ':');
+    namedLoggers[name] = createLogFunctions(name + ':');
   }
 
   return namedLoggers[name];

--- a/renderer.js
+++ b/renderer.js
@@ -11,16 +11,11 @@ try {
 
 var originalConsole = require('./lib/original-console');
 
+var namedLoggers = {};
+
 if (ipcRenderer) {
-  module.exports = {
-    error:   log.bind(null, 'error'),
-    warn:    log.bind(null, 'warn'),
-    info:    log.bind(null, 'info'),
-    verbose: log.bind(null, 'verbose'),
-    debug:   log.bind(null, 'debug'),
-    silly:   log.bind(null, 'silly'),
-    log:     log.bind(null, 'info')
-  };
+  module.exports = createLogFunctions;
+  module.exports.createNamedLogger = createNamedLogger;
 
   module.exports.default = module.exports;
 
@@ -36,6 +31,26 @@ if (ipcRenderer) {
       typeof data === 'string' ? [data] : data
     );
   });
+}
+
+function createLogFunctions(prependMessage) {
+  return {
+    error:    log.bind(null, 'error', prependMessage),
+    warn:     log.bind(null, 'warn', prependMessage),
+    info:     log.bind(null, 'info', prependMessage),
+    verbose:  log.bind(null, 'verbose', prependMessage),
+    debug:    log.bind(null, 'debug', prependMessage),
+    silly:    log.bind(null, 'silly', prependMessage),
+    log:      log.bind(null, 'info', prependMessage)
+  }
+}
+
+function createNamedLogger(name) {
+  if (!namedLoggers[name]) {
+    namedLoggers[name] = createLogFunctions(transports, name + ':');
+  }
+
+  return namedLoggers[name];
 }
 
 function log() {


### PR DESCRIPTION
This PR adds a new feature: Named loggers.

The `electron-log` module exports a new function `createNamedLogger(name)` which lets the user create a new logger.

Each log message will be prepended by the logger's name and ':'.

TODO:
[ ] Update typescript definition
[ ] Add additional tests, especially for the renderer process

This change may need additional work for the 3.0.0-beta.
If you agree to include this feature, I'll resolve the todos. Otherwise feel free to close it.