### PR TITLE
fix(transports/console): undefined style in cssToAnsi

### DIFF
--- a/lib/transports/console.js
+++ b/lib/transports/console.js
@@ -38,7 +38,7 @@ function consoleTransportFactory(electronLog) {
       return;
     }
 
-    var styles = msg.styles;
+    var styles = msg.styles || [];
 
     if (transport.format.substr && transport.format.substr(0, 2) === '%c') {
       styles = ['color:' + levelToStyle(msg.level), 'color:unset']


### PR DESCRIPTION
Without this change, msg.styles can be undefined, which causes the styles array to have an undefined element at the end, which causes applyAnsiStyles to call cssToAnsi(undefined) which crashes because of undefined.replace

[The logConsole function](https://github.com/megahertz/electron-log/blob/24f59d9b90e634932e801870ade69e2fa6cd9a84/lib/transports/file/index.js#L126) in the file transport (used to log electron-log warnings directly to the console) does not include a `styles` field when it calls the console transporter. This causes the above error, where msg.styles is undefined and crashes later.

Example crash:
```
TypeError: Cannot read property 'replace' of undefined
    at cssToAnsi (/Users/.../project/node_modules/electron-log/lib/transports/console.js:83:21)
    at /Users/.../project/node_modules/electron-log/lib/transports/console.js:62:31
    at Array.forEach (<anonymous>)
    at applyAnsiStyles (/Users/.../project/node_modules/electron-log/lib/transports/console.js:61:10)
    at Object.transport [as console] (/Users/.../project/node_modules/electron-log/lib/transports/console.js:53:30)
    at logConsole (/Users/.../project/node_modules/electron-log/lib/transports/file/index.js:126:28)
    at Function.clear (/Users/.../project/node_modules/electron-log/lib/transports/file/index.js:110:7)
    at Object.<anonymous> (/Users/.../project/src/log.js:32:23)
    at Object.<anonymous> (/Users/.../project/src/log.js:80:3)
    at Module._compile (internal/modules/cjs/loader.js:693:30)
```