### PR TITLE
Fix: findLogPath mkDir Windows UNC

### DIFF
--- a/lib/transports/file/findLogPath.js
+++ b/lib/transports/file/findLogPath.js
@@ -81,10 +81,12 @@ function prepareDir(dirPath) {
 
 function mkDir(dirPath, root) {
   // Handle Windows UNC path
-  var uncRegex = /^[\\\/]{2,}[^\\\/]+[\\\/]+[^\\\/]+/
+  // The '\\SERVER\Share' part of a UNC path must not be checked separated
+  var uncRegex = /^([\\\/]{2,}[^\\\/]+[\\\/]+[^\\\/]+)(.*)/ // Adapted from https://github.com/regexhq/unc-path-regex
   if (root === undefined && uncRegex.test(dirPath)) { 
-    root = dirPath.match(uncRegex)[0] // UNC server name + share name is root
-    dirPath = dirPath.split(uncRegex).pop()
+    var parts =  dirPath.match(uncRegex)
+    root = parts[1] // server & share
+    dirPath = parts[2] // remaining path
   }
   
   var dirs = dirPath.split(path.sep);

--- a/lib/transports/file/findLogPath.js
+++ b/lib/transports/file/findLogPath.js
@@ -80,6 +80,13 @@ function prepareDir(dirPath) {
 }
 
 function mkDir(dirPath, root) {
+  // Handle Windows UNC path
+  var uncRegex = /^[\\\/]{2,}[^\\\/]+[\\\/]+[^\\\/]+/
+  if (root === undefined && uncRegex.test(dirPath)) { 
+    root = dirPath.match(uncRegex)[0] // UNC server name + share name is root
+    dirPath = dirPath.split(uncRegex).pop()
+  }
+  
   var dirs = dirPath.split(path.sep);
   var dir = dirs.shift();
   root = (root || '') + dir + path.sep;

--- a/lib/transports/file/findLogPath.js
+++ b/lib/transports/file/findLogPath.js
@@ -81,14 +81,15 @@ function prepareDir(dirPath) {
 
 function mkDir(dirPath, root) {
   // Handle Windows UNC path
-  // The '\\SERVER\Share' part of a UNC path must not be checked separated
-  var uncRegex = /^([\\\/]{2,}[^\\\/]+[\\\/]+[^\\\/]+)(.*)/ // Adapted from https://github.com/regexhq/unc-path-regex
-  if (root === undefined && uncRegex.test(dirPath)) { 
-    var parts =  dirPath.match(uncRegex)
-    root = parts[1] // server & share
-    dirPath = parts[2] // remaining path
+  // The '\\SERVER\Share' part of a UNC path must not be separated
+  // Regex Adapted from https://github.com/regexhq/unc-path-regex
+  var uncRegex = /^([\\/]{2,}[^\\/]+[\\/]+[^\\/]+)(.*)/;
+  if (root === undefined && uncRegex.test(dirPath)) {
+    var parts =  dirPath.match(uncRegex):
+    root = parts[1]; // server & share
+    dirPath = parts[2]; // remaining path
   }
-  
+
   var dirs = dirPath.split(path.sep);
   var dir = dirs.shift();
   root = (root || '') + dir + path.sep;

--- a/lib/transports/file/findLogPath.js
+++ b/lib/transports/file/findLogPath.js
@@ -85,7 +85,7 @@ function mkDir(dirPath, root) {
   // Regex Adapted from https://github.com/regexhq/unc-path-regex
   var uncRegex = /^([\\/]{2,}[^\\/]+[\\/]+[^\\/]+)(.*)/;
   if (root === undefined && uncRegex.test(dirPath)) {
-    var parts =  dirPath.match(uncRegex):
+    var parts =  dirPath.match(uncRegex);
     root = parts[1]; // server & share
     dirPath = parts[2]; // remaining path
   }


### PR DESCRIPTION
The mkDir function did not correctly handle Windows UNC (e.g. `\\Server\Share`) paths.
By specification UNC paths must not consist only of a server name. Thus, `path.resolve ('\\Server')` resolves to `C:\Server` but `path.resolve('\\Server\Share')` resolves to `\\Server\Share`.
The implementation is splitting the path to resolve/create it directory by directory, but it must not separate the first UNC part, as it creates wrong directories and/or may run into permission errors.

Related node issue: https://github.com/nodejs/node-v0.x-archive/issues/25552
UNC specification: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc
My fix uses the slightly modifieed regex from https://github.com/regexhq/unc-path-regex to handle the unc path.

The electron-log package failed to create the default logging directory on a system where the AppData folder was directed to a UNC share path. It threw an Error `ENOENT: no such file or directory, stat 'C:\SERVERNAME'` as it tried to resolve the UNC path part by part.