### PR TITLE
Add option rejectUnauthorized on remote transport for HTTPS connections

### DIFF
--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -11,7 +11,7 @@ function remoteTransportFactory() {
   transport.depth  = 6;
   transport.level  = false;
   transport.url    = null;
-  transport.https = {rejectUnauthorized: false}
+  transport.https = {rejectUnauthorized: true}
 
   return transport;
 }

--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -47,8 +47,8 @@ function post(serverUrl, data) {
       'Content-Type':   'application/json'
     }
   };
-  
-  Object.assign(options, transport.requestOptions); 
+
+  Object.assign(options, transport.requestOptions);
 
   var request = htTransport.request(options);
   request.write(body);

--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -11,7 +11,7 @@ function remoteTransportFactory() {
   transport.depth  = 6;
   transport.level  = false;
   transport.url    = null;
-  transport.https = {rejectUnauthorized: true}
+  transport.https = { rejectUnauthorized: true };
 
   return transport;
 }
@@ -42,7 +42,7 @@ function post(serverUrl, data) {
     port:     urlObject.port,
     path:     urlObject.path,
     method:   'POST',
-	rejectUnauthorized: transport.https.rejectUnauthorized,
+    rejectUnauthorized: transport.https.rejectUnauthorized,
     headers:  {
       'Content-Length': body.length,
       'Content-Type':   'application/json'

--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -7,11 +7,12 @@ var url   = require('url');
 module.exports = remoteTransportFactory;
 
 function remoteTransportFactory() {
-  transport.client = { name: 'electron-application' };
-  transport.depth  = 6;
-  transport.level  = false;
-  transport.url    = null;
+  transport.client         = { name: 'electron-application' };
+  transport.depth          = 6;
+  transport.level          = false;
   transport.requestOptions = {};
+  transport.url            = null;
+  
 
   return transport;
 }

--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -12,7 +12,6 @@ function remoteTransportFactory() {
   transport.level          = false;
   transport.requestOptions = {};
   transport.url            = null;
-  
 
   return transport;
 }

--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -11,6 +11,7 @@ function remoteTransportFactory() {
   transport.depth  = 6;
   transport.level  = false;
   transport.url    = null;
+  transport.https = {rejectUnauthorized: false}
 
   return transport;
 }
@@ -41,6 +42,7 @@ function post(serverUrl, data) {
     port:     urlObject.port,
     path:     urlObject.path,
     method:   'POST',
+	rejectUnauthorized: transport.https.rejectUnauthorized,
     headers:  {
       'Content-Length': body.length,
       'Content-Type':   'application/json'

--- a/lib/transports/remote.js
+++ b/lib/transports/remote.js
@@ -11,7 +11,7 @@ function remoteTransportFactory() {
   transport.depth  = 6;
   transport.level  = false;
   transport.url    = null;
-  transport.https = { rejectUnauthorized: true };
+  transport.requestOptions = {};
 
   return transport;
 }
@@ -42,12 +42,13 @@ function post(serverUrl, data) {
     port:     urlObject.port,
     path:     urlObject.path,
     method:   'POST',
-    rejectUnauthorized: transport.https.rejectUnauthorized,
     headers:  {
       'Content-Length': body.length,
       'Content-Type':   'application/json'
     }
   };
+  
+  Object.assign(options, transport.requestOptions); 
 
   var request = htTransport.request(options);
   request.write(body);


### PR DESCRIPTION
Option https.rejectUnauthorized was add to remote transport to allow self-signed certificates on server side. Default value (true) was not changed.