### PR TITLE
added export to IElectronLog interface

### DIFF
--- a/electron-log.d.ts
+++ b/electron-log.d.ts
@@ -223,7 +223,7 @@ declare interface ICatchErrorsResult {
   stop(): void;
 }
 
-declare interface IElectronLog {
+export declare interface IElectronLog {
   /**
    * Transport instances
    */


### PR DESCRIPTION
export the interface helps ts users working with the logger in case of dependency injection (for example if you need to mock the logger in the unit tests) 