### PR TITLE
Name property should be checked before reassignment

### DIFF
--- a/lib/catchErrors.js
+++ b/lib/catchErrors.js
@@ -46,17 +46,15 @@ module.exports = function catchErrors(options) {
 
   function onRejection(reason) {
     if (reason instanceof Error) {
+      var reasonName = 'UnhandledRejection ' + reason.name
+      
       var errPrototype = Object.getPrototypeOf(reason);
       var nameProperty = Object.getOwnPropertyDescriptor(errPrototype, 'name');
-
-      if (nameProperty && nameProperty.writable) {
-        reason.name = 'UnhandledRejection ' + reason.name;
-      } else {
-        var name = reason.name;
+      if (!nameProperty || !nameProperty.writable) {
         reason = new Error(reason.message);
-        reason.name = 'UnhandledRejection ' + name;
-      }
-
+      } 
+        
+      reason.name = reasonName;
       onError(reason);
       return;
     }

--- a/lib/catchErrors.js
+++ b/lib/catchErrors.js
@@ -46,7 +46,16 @@ module.exports = function catchErrors(options) {
 
   function onRejection(reason) {
     if (reason instanceof Error) {
-      reason.name = 'UnhandledRejection ' + reason.name;
+      var nameProperty = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(reason), 'name');
+
+      if (nameProperty && nameProperty.writable) {
+        reason.name = 'UnhandledRejection ' + reason.name;
+      } else {
+        var name = reason.name;
+        reason = new Error(reason.message);
+        reason.name = 'UnhandledRejection ' + name;
+      }
+
       onError(reason);
       return;
     }

--- a/lib/catchErrors.js
+++ b/lib/catchErrors.js
@@ -46,7 +46,8 @@ module.exports = function catchErrors(options) {
 
   function onRejection(reason) {
     if (reason instanceof Error) {
-      var nameProperty = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(reason), 'name');
+      var errPrototype = Object.getPrototypeOf(reason);
+      var nameProperty = Object.getOwnPropertyDescriptor(errPrototype, 'name');
 
       if (nameProperty && nameProperty.writable) {
         reason.name = 'UnhandledRejection ' + reason.name;


### PR DESCRIPTION
The issue is a `DOMException` (https://developer.mozilla.org/en-US/docs/Web/API/DOMException) can be passed into the `onRejection` function but its `name` property is `readonly` which causes an error when trying to assign to `reason.name`.