### PR TITLE
Fix type of IHook.selectedTransport

### DIFF
--- a/electron-log.d.ts
+++ b/electron-log.d.ts
@@ -10,7 +10,7 @@ export type IFOpenFlags = "r" | "r+" | "rs+" | "w" | "wx" | "w+" | "wx+" |
 
 export type IHook = (
   msg: ILogMessage,
-  selectedTransports?: ITransports,
+  selectedTransport?: ITransport,
 ) => ILogMessage | false;
 
 export interface IVariables {


### PR DESCRIPTION
The actual type of the second argument of `IHook` is `ITransport` according to [this line](https://github.com/megahertz/electron-log/blob/318bb92e2741629f7e80d89d0596072ddf6a75b1/lib/log.js#L16) and my own experiments