### PR TITLE
Upgrade to Electron 7.x

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ function onIpcMain(channel, listener) {
     return;
   }
 
-  electron.ipcMain.handle(channel, listener);
+  electron.ipcMain.on(channel, listener);
 }
 
 function onIpcRenderer(channel, listener) {
@@ -91,7 +91,7 @@ function sendIpcToMain(channel, message) {
     return;
   }
 
-  electron.ipcRenderer.invoke(channel, message);
+  electron.ipcRenderer.send(channel, message);
 }
 
 function sendIpcToRenderer(channel, message) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,7 @@ function getElectronAppName() {
   var app = getElectronApp();
   if (!app) return null;
 
-  return app.name;
+  return 'name' in app ? app.name : app.getName();
 }
 
 function getElectronModule(name) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,7 @@ function getElectronAppName() {
   var app = getElectronApp();
   if (!app) return null;
 
-  return app.getName();
+  return app.name;
 }
 
 function getElectronModule(name) {
@@ -75,7 +75,7 @@ function onIpcMain(channel, listener) {
     return;
   }
 
-  electron.ipcMain.on(channel, listener);
+  electron.ipcMain.handle(channel, listener);
 }
 
 function onIpcRenderer(channel, listener) {
@@ -91,7 +91,7 @@ function sendIpcToMain(channel, message) {
     return;
   }
 
-  electron.ipcRenderer.send(channel, message);
+  electron.ipcRenderer.invoke(channel, message);
 }
 
 function sendIpcToRenderer(channel, message) {


### PR DESCRIPTION
This PR introduces changes that have been marked as deprecated in the latest Electron version 7.x

- Use name property to get the application name
- Use `ipcRenderer.invoke()` and `ipcMain.handle()` for asynchronous communication between the main and the renderer process.