### PR TITLE
Added requestOptions to RemoteTransport type

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "bugs": "https://github.com/megahertz/electron-log/issues",
   "homepage": "https://github.com/megahertz/electron-log#readme",
   "devDependencies": {
+    "@types/node": "^13.1.8",
     "electron": "*",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-base": "^13.2.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -268,14 +268,14 @@ declare namespace ElectronLog {
     depth?: number;
 
     /**
-     * Server URL
-     */
-    url: string;
-
-    /**
      * Additional options for the HTTP request
      */
     requestOptions?: RequestOptions;
+    
+    /**
+     * Server URL
+     */
+    url: string;
   }
 
   interface Transports {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import { RequestOptions } from "http";
+
 declare namespace ElectronLog {
   type LogLevel = 'error' | 'warn' | 'info' | 'verbose' | 'debug' |
     'silly';
@@ -269,6 +271,11 @@ declare namespace ElectronLog {
      * Server URL
      */
     url: string;
+
+    /**
+     * Additional options for the HTTP request
+     */
+    requestOptions?: RequestOptions;
   }
 
   interface Transports {


### PR DESCRIPTION
Hello, @megahertz! Noticed that requestOptions was not in the type definitions.

Added that with the http.RequestOptions type.