### PR TITLE
Fix type definition for customFormat

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare namespace ElectronLog {
   type LevelOption = LogLevel | false;
   type Levels = Array<LogLevel | string>;
 
-  type Format = (message: LogMessage) => void;
+  type Format = (message: LogMessage, data: any[]) => any[];
 
   type FopenFlags = 'r' | 'r+' | 'rs+' | 'w' | 'wx' | 'w+' | 'wx+' |
     'a' | 'ax' | 'a+' | 'ax+';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare namespace ElectronLog {
   type LevelOption = LogLevel | false;
   type Levels = Array<LogLevel | string>;
 
-  type Format = (message: LogMessage, data: any[]) => any[];
+  type Format = (message: LogMessage, transformedData?: any[]) => any[] | string;
 
   type FopenFlags = 'r' | 'r+' | 'rs+' | 'w' | 'wx' | 'w+' | 'wx+' |
     'a' | 'ax' | 'a+' | 'ax+';


### PR DESCRIPTION
when the customFormat is being called, data is passed in as an argument; the type definition said the function shouldn't return anything, but the code actually expects it to return a new data array.

I found this while trying to track down another issue - setting the format to just `"{text}"` was randomly putting spaces in front of some lines. switched to just returning the raw data, after a detour of getting all lines as `null`/`undefined` since the type said not to return anything