### PR TITLE
opimize: prevent add multiple error listener

### DIFF
--- a/src/transports/file/index.js
+++ b/src/transports/file/index.js
@@ -16,9 +16,11 @@ function fileTransportFactory(electronLog, customRegistry) {
   var pathVariables = variables.getPathVariables(process.platform);
 
   var registry = customRegistry || globalRegistry;
-  registry.on('error', function (e, file) {
-    logConsole('Can\'t write to ' + file, e);
-  });
+  if (registry.listenerCount('error') <= 0) {
+    registry.on('error', function (e, file) {
+      logConsole('Can\'t write to ' + file, e);
+    });
+  }
 
   /* eslint-disable no-multi-spaces */
   transport.archiveLog   = archiveLog;

--- a/src/transports/file/index.js
+++ b/src/transports/file/index.js
@@ -16,7 +16,7 @@ function fileTransportFactory(electronLog, customRegistry) {
   var pathVariables = variables.getPathVariables(process.platform);
 
   var registry = customRegistry || globalRegistry;
-  if (registry.listenerCount('error') <= 0) {
+  if (registry.listenerCount('error') < 1) {
     registry.on('error', function (e, file) {
       logConsole('Can\'t write to ' + file, e);
     });


### PR DESCRIPTION
When there are multiple log instances, we will get warning: 

```
(node:29083) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [FileRegistry]. Use emitter.setMaxListeners() to increase limit
```

This PR make sure only one error listener to be added to `globalRegistry`