### PR TITLE
Configurable transports to run on remote transport error

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -71,6 +71,14 @@ Default: `data => JSON.stringify(data)`
 
 Callback which transforms request body to string
 
+#### `errorTransports` [array]
+
+Default: `[electronLog.transports.console, electronLog.transports.ipc, electronLog.transports.file]`
+
+If the network request fails, electron-log will log the error message to specified transports. By default the
+error messages are also logged to file, however it is recommended to disable file logging on devices with
+low disc speed as it would double the disc writes if the device is behind a firewall or not connected to the Internet.
+
 #### **`url`** {string}
 
 Default: `undefined`

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -73,7 +73,7 @@ Callback which transforms request body to string
 
 #### `errorTransports` [array]
 
-Default: `[electronLog.transports.console, electronLog.transports.ipc, electronLog.transports.file]`
+Default: `null` (sending to console, ipc and file)
 
 If the network request fails, electron-log will log the error message to specified transports. By default the
 error messages are also logged to file, however it is recommended to disable file logging on devices with

--- a/src/transports/remote.js
+++ b/src/transports/remote.js
@@ -15,11 +15,7 @@ function remoteTransportFactory(electronLog) {
   transport.requestOptions = {};
   transport.url = null;
   transport.transformBody = function (body) { return JSON.stringify(body) };
-  transport.errorTransports = [
-    electronLog.transports.console,
-    electronLog.transports.ipc,
-    electronLog.transports.file,
-  ];
+  transport.errorTransports = null; // not specifying here as that would make it depend on other transport on initialization
 
   return transport;
 
@@ -51,7 +47,14 @@ function remoteTransportFactory(electronLog) {
         level: 'warn',
       };
 
-      log.runTransports(transport.errorTransports, errorMessage, electronLog);
+      var defaultTransports = [
+        electronLog.transports.console,
+        electronLog.transports.ipc,
+        electronLog.transports.file,
+      ];
+      var transports = transport.errorTransports ? transport.errorTransports : defaultTransports;
+
+      log.runTransports(transports, errorMessage, electronLog);
     });
   }
 }

--- a/src/transports/remote.js
+++ b/src/transports/remote.js
@@ -15,6 +15,11 @@ function remoteTransportFactory(electronLog) {
   transport.requestOptions = {};
   transport.url = null;
   transport.transformBody = function (body) { return JSON.stringify(body) };
+  transport.errorTransports = [
+    electronLog.transports.console,
+    electronLog.transports.ipc,
+    electronLog.transports.file,
+  ];
 
   return transport;
 
@@ -46,13 +51,7 @@ function remoteTransportFactory(electronLog) {
         level: 'warn',
       };
 
-      var transports = [
-        electronLog.transports.console,
-        electronLog.transports.ipc,
-        electronLog.transports.file,
-      ];
-
-      log.runTransports(transports, errorMessage, electronLog);
+      log.runTransports(transport.errorTransports, errorMessage, electronLog);
     });
   }
 }


### PR DESCRIPTION
We noticed an application slowing down and eventually crashing on certain low powered Windows devices (compute stick for an example). It seems that Windows 10 Enterprise is somehow blocking the requests made by Node (or Node is denied network access via firewall or the device is simply not connected to the Internet), then each failing request would also log the error message to a file in **addition** to the normal log messages that are written to a file. If the device is not fast enough, it will eventually queue up the writes and slow down the electron program. This PR makes it possible to override which transports are run when the http request fails.

(I would have liked to define the transports in the constructor, but then it would require initializing other transports before remote transport, thus making it depend on them. The null workaround avoids that)