### PR TITLE
Make sure we don't pass undefined to JSON.parse

### DIFF
--- a/src/transform/__specs__/object.spec.js
+++ b/src/transform/__specs__/object.spec.js
@@ -42,4 +42,13 @@ describe('transform/object', function () {
       expect(function () { object.toJSON(safeObj) }).not.toThrow();
     });
   });
+
+  describe('toString', function () {
+    it('should not throw when stringify undefined value', function () {
+      var error = new Error();
+      delete error.stack;
+
+      expect(function () { object.toStringFactory()([error]) }).not.toThrow();
+    });
+  });
 });

--- a/src/transform/object.js
+++ b/src/transform/object.js
@@ -125,7 +125,12 @@ function toStringFactory(depth) {
         return undefined;
       }
 
-      return JSON.parse(JSON.stringify(item, createSerializer(), '  '));
+      var str = JSON.stringify(item, createSerializer(), '  ');
+      if (str === undefined) {
+        return undefined;
+      }
+
+      return JSON.parse(str);
     });
 
     if (util.formatWithOptions) {


### PR DESCRIPTION
Got caught by this today when my logger tried to log an error created by rxjs that did not include a stack trace
https://github.com/ReactiveX/rxjs/blob/master/src/internal/util/TimeoutError.ts