### PR TITLE
failed to locate package.json when asar is disabled

### DIFF
--- a/src/transports/file/packageJson.js
+++ b/src/transports/file/packageJson.js
@@ -16,6 +16,7 @@ module.exports = {
 function readPackageJson() {
   return tryReadJsonAt(require.main && require.main.filename)
     || tryReadJsonAt(process.resourcesPath, 'app.asar')
+    || tryReadJsonAt(process.resourcesPath, 'app')
     || tryReadJsonAt(process.cwd())
     || { name: null, version: null };
 }


### PR DESCRIPTION
When asar option is enabled, package.json is inside `Contents/Resources/app.asar/package.json`, otherwise it should be `Contents/Resources/app/package.json`. 