### PR TITLE
fix: printing of irrelevant source in the chrome dev console

### DIFF
--- a/src/transports/console.js
+++ b/src/transports/console.js
@@ -88,9 +88,10 @@ function canUseStyles(useStyleValue, level) {
 
 function consoleLog(level, args) {
   if (original[level]) {
-    original[level].apply(original.context, args);
+    // using setTimeout to detach from the source, as a fix for issue #207
+    setTimeout(original[level].bind(original.context, ...args));
   } else {
-    original.log.apply(original.context, args);
+    setTimeout(original.log.bind(original.context, ...args));
   }
 }
 


### PR DESCRIPTION
calling with setTimeout will detach the function from the source, and there by won't print irrelevant line number in the console. Fixes #207