### PR TITLE
check that webContents has not been destroyed

### DIFF
--- a/src/electronApi.js
+++ b/src/electronApi.js
@@ -204,9 +204,9 @@ function sendIpcToRenderer(channel, message) {
   }
 
   electron.BrowserWindow.getAllWindows()
-    .map(function (wnd) { return wnd.webContents; })
-    .filter(function (wc) { return wc && !wc.isDestroyed(); })
-    .forEach(function (wc) { wc.send(channel, message); });
+    .map(function (wnd) { return wnd.webContents })
+    .filter(function (wc) { return wc && !wc.isDestroyed() })
+    .forEach(function (wc) { wc.send(channel, message) });
 }
 
 function showErrorBox(title, message) {

--- a/src/electronApi.js
+++ b/src/electronApi.js
@@ -204,7 +204,7 @@ function sendIpcToRenderer(channel, message) {
   }
 
   electron.BrowserWindow.getAllWindows().forEach(function (wnd) {
-    wnd.webContents && wnd.webContents.send(channel, message);
+    wnd.webContents && !wnd.webContents.isDestroyed() && wnd.webContents.send(channel, message);
   });
 }
 

--- a/src/electronApi.js
+++ b/src/electronApi.js
@@ -203,9 +203,10 @@ function sendIpcToRenderer(channel, message) {
     return;
   }
 
-  electron.BrowserWindow.getAllWindows().forEach(function (wnd) {
-    wnd.webContents && !wnd.webContents.isDestroyed() && wnd.webContents.send(channel, message);
-  });
+  electron.BrowserWindow.getAllWindows()
+    .map(function (wnd) { return wnd.webContents; })
+    .filter(function (wc) { return wc && !wc.isDestroyed(); })
+    .forEach(function (wc) { wc.send(channel, message); });
 }
 
 function showErrorBox(title, message) {

--- a/src/electronApi.js
+++ b/src/electronApi.js
@@ -203,10 +203,11 @@ function sendIpcToRenderer(channel, message) {
     return;
   }
 
-  electron.BrowserWindow.getAllWindows()
-    .map(function (wnd) { return wnd.webContents })
-    .filter(function (wc) { return wc && !wc.isDestroyed() })
-    .forEach(function (wc) { wc.send(channel, message) });
+  electron.BrowserWindow.getAllWindows().forEach(function (wnd) {
+    if (wnd.webContents && !wnd.webContents.isDestroyed()) {
+      wnd.webContents.send(channel, message);
+    }
+  });
 }
 
 function showErrorBox(title, message) {


### PR DESCRIPTION
When sending the  message to the renderers we have to make sure that they are ready to receive it by ensuring that the `WebContents` has not been destroyed. Otherwise Electron will crash with `TypeError: Object has been destroyed`.

An easy way to reproduce it is to create a browser window, log something on its `destroyed` event and then close the window:

```js
bw.webContents.on('destroyed', () => {
  logger.info('this will crash Electron when the window is closed');
});
```