### PR TITLE
fix getHome function to get home dir

### DIFF
--- a/src/transports/file/variables.js
+++ b/src/transports/file/variables.js
@@ -38,7 +38,7 @@ function getAppData(platform) {
 }
 
 function getHome() {
-  return os.homedir ? os.homedir() : process.env.HOME;
+  return os.homedir() ? os.homedir() : process.env.HOME;
 }
 
 function getLibraryDefaultDir(platform, appName) {


### PR DESCRIPTION
41:  os.homedir() ? os.homedir() : process.env.HOME;
os.homedir is a function, so it must be true, may cause problems, such as :
The "path" argument must be of type string. Received type object

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
    at validateString (internal/validators.js:112:11)
    at Object.join (path.js:1040:7)
    at getLibraryDefaultDir (/Volumes/cloud-files-download 0.0.1/cloud-files-download.app/Contents/Resources/app.asar.unpacked/node_modules/electron-log/src/transports/file/variables.js:46:17)
    at Object.getPathVariables (/Volumes/cloud-files-download 0.0.1/cloud-files-download.app/Contents/Resources/app.asar.unpacked/node_modules/electron-log/src/transports/file/variables.js:100:24)
    at fileTransportFactory (/Volumes/cloud-files-download 0.0.1/cloud-files-download.app/Contents/Resources/app.asar.unpacked/node_modules/electron-log/src/transports/file/index.js:17:33)
    at create (/Volumes/cloud-files-download 0.0.1/cloud-files-download.app/Contents/Resources/app.asar.unpacked/node_modules/electron-log/src/index.js:47:11)
    at Object.<anonymous> (/Volumes/cloud-files-download 0.0.1/cloud-files-download.app/Contents/Resources/app.asar.unpacked/node_modules/electron-log/src/index.js:12:18)
    at Module._compile (internal/modules/cjs/loader.js:968:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:986:10)
    at Module.load (internal/modules/cjs/loader.js:816:32)