### PR TITLE
fix(remote): Merge standard headers with caller-supplied ones (if any)

### DIFF
--- a/src/transports/remote.js
+++ b/src/transports/remote.js
@@ -69,13 +69,15 @@ function post(serverUrl, requestOptions, body) {
     port:     urlObject.port,
     path:     urlObject.path,
     method:   'POST',
-    headers:  {
-      'Content-Length': body.length,
-      'Content-Type':   'application/json',
-    },
+    headers:  {},
   };
 
   Object.assign(options, requestOptions);
+
+  options.headers['Content-Length'] = body.length;
+  if (!options.headers['Content-Type']) {
+    options.headers['Content-Type'] = 'application/json';
+  }
 
   var request = httpTransport.request(options);
   request.write(body);


### PR DESCRIPTION
Currently, if an application includes any HTTP headers in its `requestOptions`, that object will overwrite the `Content-Length` and `Content-Type` headers set by the transport. This PR fixes that.