### PR TITLE
Remote transport: wrong Content-Length for UTF8 strings #279

### DIFF
--- a/src/transports/remote.js
+++ b/src/transports/remote.js
@@ -75,7 +75,7 @@ function post(serverUrl, requestOptions, body) {
 
   Object.assign(options, requestOptions);
 
-  options.headers['Content-Length'] = body.length;
+  options.headers['Content-Length'] = new Blob([body]).size;
   if (!options.headers['Content-Type']) {
     options.headers['Content-Type'] = 'application/json';
   }


### PR DESCRIPTION
the TextEncoder seems to be generally slower than other approaches, using Blob instead