### PR TITLE
readAllLogs: Only include files that end with `.log`

### DIFF
--- a/src/transports/file/index.js
+++ b/src/transports/file/index.js
@@ -114,18 +114,18 @@ function fileTransportFactory(electronLog, customRegistry) {
     return path.join(vars.libraryDefaultDir, vars.fileName);
   }
 
-  function readAllLogs() {
+  function readAllLogs(options) {
+    var fileFilter = (options && typeof options.fileFilter === 'function')
+      || function (fileName) { return fileName.endsWith('.log') };
     var vars = Object.assign({}, pathVariables, {
       fileName: transport.fileName,
     });
     var logsPath = path.dirname(transport.resolvePath(vars));
 
     return fs.readdirSync(logsPath)
-      .filter(function (fileName) {
-        return fileName.endsWith('.log');
-      })
-      .map(function (fileName) {
-        var logPath = path.join(logsPath, fileName);
+      .map(function (fileName) { return path.join(logsPath, fileName) })
+      .filter(fileFilter)
+      .map(function (logPath) {
         try {
           return {
             path: logPath,

--- a/src/transports/file/index.js
+++ b/src/transports/file/index.js
@@ -121,6 +121,9 @@ function fileTransportFactory(electronLog, customRegistry) {
     var logsPath = path.dirname(transport.resolvePath(vars));
 
     return fs.readdirSync(logsPath)
+      .filter(function (fileName) {
+        return fileName.endsWith('.log');
+      })
       .map(function (fileName) {
         var logPath = path.join(logsPath, fileName);
         try {


### PR DESCRIPTION
I used this function and it included a `.DS_Store` file. I think it is reasonable to filter out non-`.log` files.

I tested the change with my application.

Let me know if you want me to make any changes!