### PR TITLE
fix: ElectronExternalApi fallback to super when electron app is undefined, fixes #399

### DIFF
--- a/src/main/ElectronExternalApi.js
+++ b/src/main/ElectronExternalApi.js
@@ -1,22 +1,21 @@
 'use strict';
 
-const electron = require('electron');
 const path = require('path');
 const NodeExternalApi = require('../node/NodeExternalApi');
 
 class ElectronExternalApi extends NodeExternalApi {
   /**
-   * @type {typeof electron}
+   * @type {typeof Electron}
    */
   electron = undefined;
 
   /**
    * @param {object} options
-   * @param {typeof electron} [options.electron]
+   * @param {typeof Electron} [options.electron]
    */
-  constructor(options = {}) {
-    super(options);
-    this.electron = options?.electron ?? electron;
+  constructor({ electron } = {}) {
+    super();
+    this.electron = electron;
   }
 
   getAppName() {
@@ -147,7 +146,7 @@ class ElectronExternalApi extends NodeExternalApi {
   setPreloadFileForSessions({
     filePath,
     includeFutureSession = true,
-    getSessions = () => [electron.session?.defaultSession],
+    getSessions = () => [this.electron.session?.defaultSession],
   }) {
     for (const session of getSessions().filter(Boolean)) {
       setPreload(session);

--- a/src/main/__specs__/ElectronExternalApi.spec.js
+++ b/src/main/__specs__/ElectronExternalApi.spec.js
@@ -4,67 +4,54 @@ const humilePkg = require('humile/package.json');
 const ElectronExternalApi = require('../ElectronExternalApi');
 
 describe('ElectronExternalApi', () => {
-  /**
-   * This test must mock the `electron` module because when
-   * requiring the module then its properties are undefined.
-   * This makes it difficult to test our API methods otherwise.
-   *
-   * @type {Electron}
-   */
-  let mockElectron;
-
-  beforeEach(() => {
-    mockElectron = undefined;
-  });
-
   describe('getAppName', () => {
     it('gets the electron app name property', () => {
-      mockElectron = {
+      const electron = {
         app: {
           name: 'test-prop',
           getName: () => 'test-func',
         },
       };
 
-      expect(api().getAppName()).toBe('test-prop');
+      expect(api({ electron }).getAppName()).toBe('test-prop');
     });
 
     it('calls the electron app name function when no name property', () => {
-      mockElectron = {
+      const electron = {
         app: {
           name: undefined,
           getName: () => 'test-func',
         },
       };
 
-      expect(api().getAppName()).toBe('test-func');
+      expect(api({ electron }).getAppName()).toBe('test-func');
     });
 
     it('fallsback to super function when no electron names', () => {
-      mockElectron = {
+      const electron = {
         app: {
           name: undefined,
           getName: undefined,
         },
       };
 
-      expect(api().getAppName()).toBe(humilePkg.name);
+      expect(api({ electron }).getAppName()).toBe(humilePkg.name);
     });
 
     it('fallsback to super function when no electron', () => {
-      mockElectron = undefined;
+      const electron = undefined;
 
-      expect(api().getAppName()).toBe(humilePkg.name);
+      expect(api({ electron }).getAppName()).toBe(humilePkg.name);
     });
   });
 
   /**
    * @param {object} options
    * @param {NodeJS.Platform} options.platform
-   * @param {Electron} options.electron
+   * @param {typeof Electron} options.electron
    * @returns {ElectronExternalApi}
    */
-  function api({ platform = process.platform, electron = mockElectron } = {}) {
+  function api({ electron, platform = process.platform } = {}) {
     const externalApi = new ElectronExternalApi({ electron });
     externalApi.setPlatform(platform);
     return externalApi;

--- a/src/main/__specs__/ElectronExternalApi.spec.js
+++ b/src/main/__specs__/ElectronExternalApi.spec.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const humilePkg = require('humile/package.json');
+const ElectronExternalApi = require('../ElectronExternalApi');
+
+describe('ElectronExternalApi', () => {
+  /**
+   * This test must mock the `electron` module because when
+   * requiring the module then its properties are undefined.
+   * This makes it difficult to test our API methods otherwise.
+   *
+   * @type {Electron}
+   */
+  let mockElectron;
+
+  beforeEach(() => {
+    mockElectron = undefined;
+  });
+
+  describe('getAppName', () => {
+    it('gets the electron app name property', () => {
+      mockElectron = {
+        app: {
+          name: 'test-prop',
+          getName: () => 'test-func',
+        },
+      };
+
+      expect(api().getAppName()).toBe('test-prop');
+    });
+
+    it('calls the electron app name function when no name property', () => {
+      mockElectron = {
+        app: {
+          name: undefined,
+          getName: () => 'test-func',
+        },
+      };
+
+      expect(api().getAppName()).toBe('test-func');
+    });
+
+    it('fallsback to super function when no electron names', () => {
+      mockElectron = {
+        app: {
+          name: undefined,
+          getName: undefined,
+        },
+      };
+
+      expect(api().getAppName()).toBe(humilePkg.name);
+    });
+
+    it('fallsback to super function when no electron', () => {
+      mockElectron = undefined;
+
+      expect(api().getAppName()).toBe(humilePkg.name);
+    });
+  });
+
+  /**
+   * @param {object} options
+   * @param {NodeJS.Platform} options.platform
+   * @param {Electron} options.electron
+   * @returns {ElectronExternalApi}
+   */
+  function api({ platform = process.platform, electron = mockElectron } = {}) {
+    const externalApi = new ElectronExternalApi({ electron });
+    externalApi.setPlatform(platform);
+    return externalApi;
+  }
+});

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const electron = require('electron');
 const ElectronExternalApi = require('./ElectronExternalApi');
 const { initialize } = require('./initialize');
 const createDefaultLogger = require('../node/createDefaultLogger');
 
-const externalApi = new ElectronExternalApi();
+const externalApi = new ElectronExternalApi({ electron });
 const defaultLogger = createDefaultLogger({
   dependencies: { externalApi },
   initializeFn: initialize,


### PR DESCRIPTION
### Background

Fixes #399 

### Changes

- Update `ElectronExternalApi.getAppName()` and `ElectronExternalApi.getAppVersion()` to fallback to `super` method just as when catching an error if `electron.app` is undefined
- Introduce dev dependency `testdouble` to help mock electron for the new unit tests