### PR TITLE
fix: timeZoneFromOffset function to return correct offset for UTC timezone

### DIFF
--- a/src/node/transforms/__specs__/format.spec.js
+++ b/src/node/transforms/__specs__/format.spec.js
@@ -135,6 +135,7 @@ describe('transform/format', () => {
 
   it('timeZoneFromOffset', () => {
     expect(format.timeZoneFromOffset(-60)).toBe('+01:00');
+    expect(format.timeZoneFromOffset(0)).toBe('+00:00');
     expect(format.timeZoneFromOffset(60)).toBe('-01:00');
     expect(format.timeZoneFromOffset(-570)).toBe('+09:30');
   });

--- a/src/node/transforms/format.js
+++ b/src/node/transforms/format.js
@@ -60,7 +60,7 @@ function concatFirstStringElements({ data }) {
 
 function timeZoneFromOffset(minutesOffset) {
   const minutesPositive = Math.abs(minutesOffset);
-  const sign = minutesOffset >= 0 ? '-' : '+';
+  const sign = minutesOffset > 0 ? '-' : '+';
   const hours = Math.floor(minutesPositive / 60).toString().padStart(2, '0');
   const minutes = (minutesPositive % 60).toString().padStart(2, '0');
   return `${sign}${hours}:${minutes}`;


### PR DESCRIPTION
Before the fix calling `timeZoneFromOffset(0)` returned `-00:00`, after the fix it returns `+00:00`