### PR TITLE
fix: check web content is crashed or not before call ipc send

### DIFF
--- a/src/main/ElectronExternalApi.js
+++ b/src/main/ElectronExternalApi.js
@@ -175,7 +175,10 @@ class ElectronExternalApi extends NodeExternalApi {
    */
   sendIpc(channel, message) {
     this.electron.BrowserWindow?.getAllWindows()?.forEach((wnd) => {
-      if (wnd.webContents?.isDestroyed() === false) {
+      if (
+        wnd.webContents?.isDestroyed() === false
+        && wnd.webContents?.isCrashed() === false
+      ) {
         wnd.webContents.send(channel, message);
       }
     });


### PR DESCRIPTION
**Issue**
When the electron renderer process is killed, the IPC communication fails and numerous error messages appear in the console.

**Way to reproduce**
Find the renderer process in the task manager/activity monitor, and kill it manually

**Solution**
Before using IPC channels, call the webContents.isCrashed() API to verify its availability.

![image](https://github.com/user-attachments/assets/29590bcd-b784-44c5-8ccc-414325b110ad)
