### PR TITLE
fix(main): Support color formatting for individual console formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.4.0
+
+- [#465](https://github.com/megahertz/electron-log/issues/465) Allow using `%c` 
+  template for the `transports.console.format`. This change may break formatting
+  if you already use `%c` in your format string. In this case, you can run 
+  `log.transports.console.transforms.shift()` before initializing the logger.
+
 ## 5.2.4
 
 - Add Buffering feature.

--- a/src/node/transports/console.js
+++ b/src/node/transports/console.js
@@ -61,7 +61,10 @@ function consoleTransportFactory(logger) {
 }
 
 function addTemplateColors({ data, message, transport }) {
-  if (!transport.format?.includes('%c')) {
+  if (
+    typeof transport.format !== 'string'
+    || !transport.format.includes('%c')
+  ) {
     return data;
   }
 

--- a/src/node/transports/console.js
+++ b/src/node/transports/console.js
@@ -61,7 +61,7 @@ function consoleTransportFactory(logger) {
 }
 
 function addTemplateColors({ data, message, transport }) {
-  if (transport.format !== DEFAULT_FORMAT) {
+  if (!transport.format?.includes('%c')) {
     return data;
   }
 


### PR DESCRIPTION
Before this fix, when I change the main console transport format:
```js
// Remove milliseconds from log format
log.transports.console.format = '%c{h}:{i}:{s}{scope}%c ' + (process.platform === 'win32' ? '>' : '›') + ' {text}';
```

Only empty messages are printed:
```
12:00:00 › 
```