### PR TITLE
docs: update console.md and file.md

### DIFF
--- a/docs/transports/console.md
+++ b/docs/transports/console.md
@@ -21,7 +21,7 @@ Default:
 
 A map of log levels to colors.
 
-#### `format` {string | (message: LogMessage) => void}
+#### `format` {string | (params: FormatParams) => any[]}
 
 Default: `'[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'`
 

--- a/docs/transports/file.md
+++ b/docs/transports/file.md
@@ -31,7 +31,7 @@ Default: `'main.log'`
 
 The actual file name without path.
 
-#### `format` {string | (message: LogMessage) => void}
+#### `format` {string | (params: FormatParams) => any[]}
 
 Default: `'[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'`
 


### PR DESCRIPTION
Hello, I noticed that the `format` type has changed, but the document has not been updated yet.

https://github.com/megahertz/electron-log/blob/09504c8f5219d703fbcd562c723f755f59a8b432/docs/transports/format.md?plain=1#L35