### PR TITLE
feat: add exports field to package.json for ESM subpath resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
+      "browser": "./src/renderer/index.js",
       "default": "./src/index.js"
     },
     "./*": "./*",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,32 @@
   "description": "Just a simple logging module for your Electron application",
   "main": "src/index.js",
   "browser": "src/renderer/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./main": {
+      "types": "./main.d.ts",
+      "import": "./main.js",
+      "require": "./main.js"
+    },
+    "./renderer": {
+      "types": "./renderer.d.ts",
+      "import": "./renderer.js",
+      "require": "./renderer.js"
+    },
+    "./preload": {
+      "import": "./preload.js",
+      "require": "./preload.js"
+    },
+    "./node": {
+      "types": "./node.d.ts",
+      "import": "./node.js",
+      "require": "./node.js"
+    },
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": ">= 14"
   },

--- a/package.json
+++ b/package.json
@@ -4,32 +4,6 @@
   "description": "Just a simple logging module for your Electron application",
   "main": "src/index.js",
   "browser": "src/renderer/index.js",
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "default": "./src/index.js"
-    },
-    "./main": {
-      "types": "./main.d.ts",
-      "import": "./main.js",
-      "require": "./main.js"
-    },
-    "./renderer": {
-      "types": "./renderer.d.ts",
-      "import": "./renderer.js",
-      "require": "./renderer.js"
-    },
-    "./preload": {
-      "import": "./preload.js",
-      "require": "./preload.js"
-    },
-    "./node": {
-      "types": "./node.d.ts",
-      "import": "./node.js",
-      "require": "./node.js"
-    },
-    "./package.json": "./package.json"
-  },
   "engines": {
     "node": ">= 14"
   },
@@ -72,6 +46,26 @@
   "license": "MIT",
   "bugs": "https://github.com/megahertz/electron-log/issues",
   "homepage": "https://github.com/megahertz/electron-log#readme",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./*": "./*",
+    "./main": {
+      "types": "./main.d.ts",
+      "default": "./main.js"
+    },
+    "./node": {
+      "types": "./node.d.ts",
+      "default": "./node.js"
+    },
+    "./preload": "./preload.js",
+    "./renderer": {
+      "types": "./renderer.d.ts",
+      "default": "./renderer.js"
+    }
+  },
   "devDependencies": {
     "@types/node": "^20.10.6",
     "electron": "*",


### PR DESCRIPTION
## Summary

Adds an `exports` field to `package.json` so that ESM consumers can use the documented bare subpath imports (`electron-log/main`, `electron-log/renderer`, `electron-log/preload`, `electron-log/node`) without having to append `.js`.

Closes #482.

## Why

`electron-log@5.4.3` does not declare an `exports` field. Node's ESM resolver does **not** auto-append `.js` for subpath imports, so projects with `"type": "module"` (e.g. Electron apps bundled by `electron-vite` after Electron 28+ ESM support) currently have to write `electron-log/main.js`, contradicting the README and the shipped `.d.ts` files. Without `.js`, resolution fails with `ERR_MODULE_NOT_FOUND` only in production bundles, which is a confusing footgun.

## What changed

Only `package.json`:

```json
"exports": {
  ".":           { "types": "./src/index.d.ts", "default": "./src/index.js" },
  "./main":      { "types": "./main.d.ts",      "import": "./main.js",     "require": "./main.js" },
  "./renderer":  { "types": "./renderer.d.ts",  "import": "./renderer.js", "require": "./renderer.js" },
  "./preload":   {                              "import": "./preload.js",  "require": "./preload.js" },
  "./node":      { "types": "./node.d.ts",      "import": "./node.js",     "require": "./node.js" },
  "./package.json": "./package.json"
}
```

- `main` / `browser` fields are left in place for legacy resolution paths.
- Both `import` and `require` conditions map to the same file (the package is CJS at the implementation level), so this is purely additive — no breaking change for existing CJS users.
- `./package.json` is exported because Node's package self-reference rules become strict once `exports` is present, and downstream tooling sometimes wants to read it.

## Verification

Locally I `npm install`'d the patched package into a fresh ESM project (`"type": "module"`, Node 24) and reran the repro from #482:

```bash
# Before this change:
$ node --input-type=module -e "import log from 'electron-log/main'"
ERR_MODULE_NOT_FOUND

# After this change:
$ node --input-type=module -e "import log from 'electron-log/main'; console.log(typeof log)"
# resolves OK (the only error is the missing 'electron' peer dep at runtime,
# which is expected outside an Electron context — resolution itself succeeds)
```

CJS continued to work for `require('electron-log')`, `require('electron-log/preload')`, `require('electron-log/node')`.

I have not run `npm run test:full` because the e2e suite requires Electron and a display; happy to do so or to adjust the `exports` shape if you prefer different conditions.

## Notes

- No source changes.
- No public-API change for current consumers.
- Lets downstream projects drop their `.js` workaround in subpath imports.
